### PR TITLE
Update RTC.js

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -188,7 +188,8 @@ var RTC = {
             // local video
             stream = this.localVideo;
         } else {
-            var peerStreams = this.remoteStreams[jid];
+            var peerJid = APP.xmpp.findJidFromResource(jid);
+            var peerStreams = this.remoteStreams[peerJid];
             if(!peerStreams)
                 return false;
             stream = peerStreams[MediaStreamType.VIDEO_TYPE];


### PR DESCRIPTION
fix for screensharing screen ratio on receiver side - full peerjid instead of jid in RTC.js in jitsi-meet commit 6c4a5bd tag 340